### PR TITLE
Import all functions on init

### DIFF
--- a/codonPython/__init__.py
+++ b/codonPython/__init__.py
@@ -1,0 +1,4 @@
+from .age_bands import *
+from .dateValidator import *
+from .nhsNumberGenerator import *
+from .tableFromSql import *


### PR DESCRIPTION
To avoid `from codonPython.age_bands import age_bands` for now.

Later it'll be better structure the package logically eg `from codonPython.utils import dateValidator`. On that note, pycodon sounds more 'pythonic' to me.