### PR TITLE
Code of conduct

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,12 @@
+* **Please check if the Pull Request fulfills these requirements**
+- [] The commit message is clear and concise
+- [] Test for the changes have been added and reviewed
+- [] Documentation has been added to all new features and editied code has had documentation reviewed
+
+* **What kind of change does this Pull request introduce?** (Bug fix, feature, docs update, ...)
+
+* **What is the current behaviour?** (Link to a current open issue if possible)
+
+* **What is the new behaviour?** (is this a feature change?)
+
+* **Does this Pull Request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,7 +1,7 @@
 * **Please check if the Pull Request fulfills these requirements**
-- [] The commit message is clear and concise
-- [] Test for the changes have been added and reviewed
-- [] Documentation has been added to all new features and editied code has had documentation reviewed
+- [ ] The commit message is clear and concise
+- [ ] Test for the changes have been added and reviewed
+- [ ] Documentation has been added to all new features and edited code has had documentation reviewed
 
 * **What kind of change does this Pull request introduce?** (Bug fix, feature, docs update, ...)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,7 @@ Start reading our code to get a feel for it:
   
 :clinking_glasses: Thank you!
 Team codon
+
+## Code of Conduct
+
+As a contributer you can help us keep the Django community open and inclusive. Please read and follow our [Code of Conduct](#)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ Start reading our code to get a feel for it:
 * We use [PEP8](https://www.python.org/dev/peps/pep-0008/). Autoformatters for PEP8, for instance [autopep8](https://pypi.org/project/autopep8/), can easily ensure compliance.
 * We use docstrings and we try to (loosely) follow [`numpy`'s docstring standards](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard).
 * This is open source software. Consider the people who will read your code, and make it look nice for them.
-  
-:clinking_glasses: Thank you!
-Team codon
 
 ## Code of Conduct
 
 As a contributer you can help us keep the Django community open and inclusive. Please read and follow our [Code of Conduct](#).
+
+:clinking_glasses: Thank you!
+Team codon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,4 +26,4 @@ Team codon
 
 ## Code of Conduct
 
-As a contributer you can help us keep the Django community open and inclusive. Please read and follow our [Code of Conduct](#)
+As a contributer you can help us keep the Django community open and inclusive. Please read and follow our [Code of Conduct](#).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Start reading our code to get a feel for it:
 
 ## Code of Conduct
 
-As a contributer you can help us keep the Django community open and inclusive. Please read and follow our [Code of Conduct](#).
+As a contributer you can help us keep the Codon community open and inclusive. Please read and follow our [Code of Conduct](#).
 
 :clinking_glasses: Thank you!
 Team codon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Start reading our code to get a feel for it:
 
 ## Code of Conduct
 
-As a contributer you can help us keep the Codon community open and inclusive. Please read and follow our [Code of Conduct](#).
+As a contributer you can help us keep the Codon community open and inclusive. Please read and follow our [Code of Conduct](https://github.com/codonlibrary/code-of-conduct/tree/master).
 
 :clinking_glasses: Thank you!
 Team codon


### PR DESCRIPTION
Contains new `pull_request_template.md` which can be found in the `.github` file. I have also made some changes to the `CONTRIBUTING.md` to contain a link to the the new Code of Conduct Repository.

@murd0, @ProjectCodon Might be worth letting @NatashaChetwynd merge this pull request.