### PR TITLE
ODS API querying helpers

### DIFF
--- a/codonPython/ODS_lookup.py
+++ b/codonPython/ODS_lookup.py
@@ -52,7 +52,8 @@ def get_addresses(codes: Iterable[str]) -> pd.DataFrame:
 
     Examples
     ---------
-    >>> get_addresses(pd.Series(["X26"]))
+    >>> result = get_addresses(pd.Series(["X26"]))
+    >>> result.reindex(columns=sorted(result.columns))
               Org_AddrLn1 Org_Code Org_Country     Org_Name Org_PostCode Org_Town
     0  1 TREVELYAN SQUARE      X26     ENGLAND  NHS Digital      LS1 6AE    LEEDS
     """

--- a/codonPython/ODS_lookup.py
+++ b/codonPython/ODS_lookup.py
@@ -1,0 +1,86 @@
+import requests
+from typing import Dict, Iterable, Callable, List, Optional
+import pandas as pd
+import numpy as np
+
+
+def query_api(code: str) -> Dict:
+    """Query the ODS API for a single org code and return the full JSON result. Full API docs can be found here:
+    https://digital.nhs.uk/services/organisation-data-service/guidance-for-developers/organisation-endpoint
+
+    Parameters
+    ----------
+    code : str
+        3 character organization code.
+
+    Returns
+    ----------
+    dict
+        The data returned from the API.
+    """
+    if not isinstance(code, str):
+        raise ValueError(f"ODS code must be a string, received {type(code)}")
+
+    response = requests.get(
+        f"https://directory.spineservices.nhs.uk/ORD/2-0-0/organisations/{code}"
+    ).json()
+    if "errorCode" in response:
+        error_code = response["errorCode"]
+        error_text = response["errorText"]
+        raise ValueError(
+            f"API query failed with code {error_code} and text '{error_text}'."
+        )
+    return response
+
+
+def get_addresses(codes: Iterable[str]) -> pd.DataFrame:
+    """Query the ODS API for a series of org codes and return
+    a data frame containing names and addresses.
+    Invalid codes will cause a message to be printed but will
+    otherwise be ignored, as an incomplete merge table is more
+    useful than no table at all.
+
+    Parameters
+    ----------
+    codes : list, ndarray or pd.Series
+        3 character organization codes to retrieve information for.
+
+    Returns
+    ----------
+    DataFrame
+        Address information for the given org codes.
+
+    Examples
+    ---------
+    >>> get_addresses(pd.Series(["X26"]))
+              Org_AddrLn1 Org_Code Org_Country     Org_Name Org_PostCode Org_Town
+    0  1 TREVELYAN SQUARE      X26     ENGLAND  NHS Digital      LS1 6AE    LEEDS
+    """
+
+    # Internal helper function to take the full result of a query
+    # and extract the relevant fields
+    def extract_data(api_result: Dict, code: str) -> Dict[str, str]:
+        org_info = api_result["Organisation"]
+        org_name = org_info["Name"]
+        org_address = org_info["GeoLoc"]["Location"]
+        result = {
+            "Org_Code": code,
+            "Org_Name": org_name.title().replace("Nhs", "NHS"),
+            **{f"Org_{k}": v for k, v in org_address.items() if k != "UPRN"},
+        }
+        return result
+
+    to_query = set(codes)
+    if np.nan in to_query:
+        # 'NaN' is actually a valid code but we don't want it for null values
+        to_query.remove(np.nan)
+
+    result = []
+    for code in to_query:
+        try:
+            api_result = query_api(code)
+            result.append(extract_data(api_result, code))
+        except ValueError as e:
+            print(f"No result for ODS code {code}. {e}")
+            continue
+    return pd.DataFrame(result)

--- a/codonPython/ODS_lookup.py
+++ b/codonPython/ODS_lookup.py
@@ -4,8 +4,9 @@ import pandas as pd
 import numpy as np
 
 
-def query_api(code: str) -> Dict:
-    """Query the ODS API for a single org code and return the full JSON result. Full API docs can be found here:
+def query_ods_api(code: str) -> Dict:
+    """Query the ODS (organisation data service) API for a single org code
+    and return the full JSON result. Full API docs can be found here:
     https://digital.nhs.uk/services/organisation-data-service/guidance-for-developers/organisation-endpoint
 
     Parameters
@@ -17,6 +18,14 @@ def query_api(code: str) -> Dict:
     ----------
     dict
         The data returned from the API.
+
+    Examples
+    ---------
+    >>> result = query_ods_api("X26")
+    >>> result["Organisation"]["Name"]
+    'NHS DIGITAL'
+    >>> result["Organisation"]["GeoLoc"]["Location"]["AddrLn1"]
+    '1 TREVELYAN SQUARE'
     """
     if not isinstance(code, str):
         raise ValueError(f"ODS code must be a string, received {type(code)}")
@@ -34,8 +43,8 @@ def query_api(code: str) -> Dict:
 
 
 def get_addresses(codes: Iterable[str]) -> pd.DataFrame:
-    """Query the ODS API for a series of org codes and return
-    a data frame containing names and addresses.
+    """Query the ODS (organisation data service) API for a series of
+    org codes and return a data frame containing names and addresses.
     Invalid codes will cause a message to be printed but will
     otherwise be ignored, as an incomplete merge table is more
     useful than no table at all.
@@ -71,6 +80,7 @@ def get_addresses(codes: Iterable[str]) -> pd.DataFrame:
         }
         return result
 
+    # Remove duplicate values
     to_query = set(codes)
     if np.nan in to_query:
         # 'NaN' is actually a valid code but we don't want it for null values
@@ -79,7 +89,7 @@ def get_addresses(codes: Iterable[str]) -> pd.DataFrame:
     result = []
     for code in to_query:
         try:
-            api_result = query_api(code)
+            api_result = query_ods_api(code)
             result.append(extract_data(api_result, code))
         except ValueError as e:
             print(f"No result for ODS code {code}. {e}")

--- a/codonPython/ODS_lookup.py
+++ b/codonPython/ODS_lookup.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 
 
-def query_ods_api(code: str) -> Dict:
+def query_api(code: str) -> Dict:
     """Query the ODS (organisation data service) API for a single org code
     and return the full JSON result. Full API docs can be found here:
     https://digital.nhs.uk/services/organisation-data-service/guidance-for-developers/organisation-endpoint
@@ -21,7 +21,7 @@ def query_ods_api(code: str) -> Dict:
 
     Examples
     ---------
-    >>> result = query_ods_api("X26")
+    >>> result = query_api("X26")
     >>> result["Organisation"]["Name"]
     'NHS DIGITAL'
     >>> result["Organisation"]["GeoLoc"]["Location"]["AddrLn1"]
@@ -89,7 +89,7 @@ def get_addresses(codes: Iterable[str]) -> pd.DataFrame:
     result = []
     for code in to_query:
         try:
-            api_result = query_ods_api(code)
+            api_result = query_api(code)
             result.append(extract_data(api_result, code))
         except ValueError as e:
             print(f"No result for ODS code {code}. {e}")

--- a/codonPython/tests/ODS_test.py
+++ b/codonPython/tests/ODS_test.py
@@ -1,0 +1,27 @@
+import pytest
+import numpy as np
+from codonPython.ODS_lookup import query_api, get_addresses
+
+
+def test_successful_query():
+    NHSD_code = "X26"
+    result = query_api(NHSD_code)
+    assert result["Organisation"]["Name"] == "NHS DIGITAL"
+
+
+def test_unsuccessful_query():
+    invalid_code = "ASDF"
+    with pytest.raises(ValueError):
+        query_api(invalid_code)
+
+
+def test_wrong_type():
+    invalid_code = 0
+    with pytest.raises(ValueError):
+        query_api(invalid_code)
+
+
+def test_unsuccessful_address_query():
+    invalid_code = ["ASDF", np.nan, None]
+    result = get_addresses(invalid_code)
+    assert result.empty

--- a/codonPython/tests/ODS_test.py
+++ b/codonPython/tests/ODS_test.py
@@ -1,27 +1,27 @@
 import pytest
 import numpy as np
-from codonPython.ODS_lookup import query_ods_api, get_addresses
+from codonPython import ODS_lookup
 
 
 def test_successful_query():
     NHSD_code = "X26"
-    result = query_ods_api(NHSD_code)
+    result = ODS_lookup.query_api(NHSD_code)
     assert result["Organisation"]["Name"] == "NHS DIGITAL"
 
 
 def test_unsuccessful_query():
     invalid_code = "ASDF"
     with pytest.raises(ValueError):
-        query_ods_api(invalid_code)
+        ODS_lookup.query_api(invalid_code)
 
 
 def test_wrong_type():
     invalid_code = 0
     with pytest.raises(ValueError):
-        query_ods_api(invalid_code)
+        ODS_lookup.query_api(invalid_code)
 
 
 def test_unsuccessful_address_query():
     invalid_code = ["ASDF", np.nan, None]
-    result = get_addresses(invalid_code)
+    result = ODS_lookup.get_addresses(invalid_code)
     assert result.empty

--- a/codonPython/tests/ODS_test.py
+++ b/codonPython/tests/ODS_test.py
@@ -1,24 +1,24 @@
 import pytest
 import numpy as np
-from codonPython.ODS_lookup import query_api, get_addresses
+from codonPython.ODS_lookup import query_ods_api, get_addresses
 
 
 def test_successful_query():
     NHSD_code = "X26"
-    result = query_api(NHSD_code)
+    result = query_ods_api(NHSD_code)
     assert result["Organisation"]["Name"] == "NHS DIGITAL"
 
 
 def test_unsuccessful_query():
     invalid_code = "ASDF"
     with pytest.raises(ValueError):
-        query_api(invalid_code)
+        query_ods_api(invalid_code)
 
 
 def test_wrong_type():
     invalid_code = 0
     with pytest.raises(ValueError):
-        query_api(invalid_code)
+        query_ods_api(invalid_code)
 
 
 def test_unsuccessful_address_query():

--- a/docs/source/codonPython.rst
+++ b/docs/source/codonPython.rst
@@ -76,6 +76,13 @@ codonPython.nhsNumber module
    :undoc-members:
    :show-inheritance:
 
+codonPython.ODS_lookup module
+----------------------------
+
+.. automodule:: codonPython.ODS_lookup
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 codonPython.suppression module
 ------------------------------


### PR DESCRIPTION
* **Please check if the Pull Request fulfills these requirements**
- [x] The commit message is clear and concise
- [x] Test for the changes have been added and reviewed
- [x] Documentation has been added to all new features and edited code has had documentation reviewed

* **What kind of change does this Pull request introduce?** (Bug fix, feature, docs update, ...)

Adds a couple of new functions for querying the [ODS API](https://digital.nhs.uk/services/organisation-data-service/guidance-for-developers/organisation-endpoint). The main one, `ODS_lookup.get_addresses`, can be used to retrieve name and address information for a list of ODS codes as a pandas data frame. e.g.
```
>>> get_addresses(pd.Series(["X26"]))
              Org_AddrLn1 Org_Code Org_Country     Org_Name Org_PostCode Org_Town
    0  1 TREVELYAN SQUARE      X26     ENGLAND  NHS Digital      LS1 6AE    LEEDS
```
	 
The api only lets you query for a single code at a time. I don't *think* making serial requests is going to cause a major performance issue but it might for very large requests. Could investigate async requests if necessary.